### PR TITLE
Send registration emails

### DIFF
--- a/goathacks/registration/__init__.py
+++ b/goathacks/registration/__init__.py
@@ -4,8 +4,9 @@ import flask_login
 from flask_login import current_user
 from goathacks.registration.forms import LoginForm, RegisterForm
 from werkzeug.security import check_password_hash, generate_password_hash
+from flask_mail import Message
 
-from goathacks import db
+from goathacks import db, mail as app_mail
 from goathacks.models import User
 
 bp = Blueprint('registration', __name__, url_prefix="/registration")
@@ -54,6 +55,16 @@ def register():
             db.session.add(user)
             db.session.commit()
             flask_login.login_user(user)
+
+            if waitlisted:
+                msg = Message("Goathacks - Waitlist Confirmation")
+            else:
+                msg = Message("GoatHacks - Registration Confirmation")
+
+            msg.add_recipient(user.email)
+            msg.sender = ("GoatHacks Team", "hack@wpi.edu")
+            msg.body = render_template("emails/registration.txt", user=user)
+            app_mail.send(msg)
 
             return redirect(url_for("dashboard.home"))
         else:


### PR DESCRIPTION
- Start rewrite
- meta: init structure
- Initial migration
- reg: Initial work on registration
- models: Add waitlisted field
- add templates
- Add WSGI file
- meta: Add database makefile recipes
- making makefile platform agnostic
- mega: Oh wow lots of things
- dash: Finish shirt size and accomodations selector
- admin: Fix admin page
- admin: Remove console.logs used for debugging
- admin: Sending bulk emails
- registration: Login
- meta: Flashed messages
- dashboard: Upload resumes
- Add example .env
- README
- fix: Send emails properly
- cli: Command-line user management
- cli: Support dropping registrations
- re-add license
- drop neovim dependency
- template: Add a link to login page from register
- meta: Make Makefile platform-agnostic
- core: Display index.html at site root
- Add static site
- Update static site
- static: Fix section linking on index.html
- admin: Fix emailing
- mail: Fix POST for mail
- registration: Add code to actually send registration emails
