### PR TITLE
separating users and admins on admin dashboard

### DIFF
--- a/goathacks/admin/__init__.py
+++ b/goathacks/admin/__init__.py
@@ -74,9 +74,8 @@ def admin_list():
 def mail():
     if not current_user.is_admin:
         return redirect(url_for("dashboard.home"))
-
-    total_count = len(db.session.execute(db.select(User).where(User.is_admin == False)).scalars().all())
-    # total_count = len(db.session.execute(db.select(User)).scalars().all())
+    
+    total_count = len(db.session.execute(db.select(User)).scalars().all())
     api_key = current_app.config["MCE_API_KEY"]
 
     return render_template("mail.html", NUM_HACKERS=total_count,

--- a/goathacks/admin/__init__.py
+++ b/goathacks/admin/__init__.py
@@ -9,9 +9,9 @@ bp = Blueprint("admin", __name__, url_prefix="/admin")
 from goathacks import db, mail as app_mail
 from goathacks.admin import events
 
-@bp.route("/")
-@login_required
-def home():
+# Helper function for admin.home and admin.admin_list to render list of users.
+# This function was abstracted to promote code reuse.
+def render_user_list(admin_list):
     if not current_user.is_admin:
         return redirect(url_for("dashboard.home"))
     male_count = 0
@@ -21,7 +21,10 @@ def home():
     waitlist_count = 0
     total_count = 0
     shirt_count = {'XS': 0, 'S': 0, 'M': 0, 'L': 0, 'XL': 0}
-    hackers = db.session.execute(db.select(User)).scalars().all()
+    if(admin_list):
+        hackers = db.session.execute(db.select(User).where(User.is_admin)).scalars().all()
+    else:
+        hackers = db.session.execute(db.select(User).where(User.is_admin == False)).scalars().all()
     schools = {}
     
     for h in hackers:
@@ -55,13 +58,25 @@ def home():
                            female_count=female_count, nb_count=nb_count,
                            check_in_count=check_in_count, schools=schools)
 
+@bp.route("/")
+@login_required
+def home():
+    return render_user_list(False) # list users (not admins)
+
+@bp.route("/admin_list")
+@login_required
+def admin_list():
+    return render_user_list(True) # list users (admins)
+
+
 @bp.route("/mail")
 @login_required
 def mail():
     if not current_user.is_admin:
         return redirect(url_for("dashboard.home"))
 
-    total_count = len(db.session.execute(db.select(User)).scalars().all())
+    total_count = len(db.session.execute(db.select(User).where(User.is_admin == False)).scalars().all())
+    # total_count = len(db.session.execute(db.select(User)).scalars().all())
     api_key = current_app.config["MCE_API_KEY"]
 
     return render_template("mail.html", NUM_HACKERS=total_count,

--- a/goathacks/templates/admin-layout.html
+++ b/goathacks/templates/admin-layout.html
@@ -20,6 +20,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="nav navbar-nav me-auto mb-2 mb-lg-0">
                 {{ render_nav_item('admin.home', 'User List')}}
+                {{ render_nav_item('admin.admin_list', 'Admin List')}}
                 {{ render_nav_item('admin.list_events', 'Event List')}}
                 {{ render_nav_item('admin.mail', 'Bulk Mail Tool')}}
             </ul>


### PR DESCRIPTION
See Github Issue #10. Added separation of admins and users on the admin dashboard.

I refactored a bit of the original admin.home endpoint into a helper function to accompany two routes that use the same template without having to copy and paste code.