### PR TITLE
Handle duplicate registration

### DIFF
--- a/goathacks/registration/__init__.py
+++ b/goathacks/registration/__init__.py
@@ -65,7 +65,7 @@ def register():
                     flash("User with email " + email + " already exists.")
                 else:
                     flash("An unknown error occurred.")
-                return render_template("register.html", form=form)
+                return redirect(url_for("registration.login"))
 
             #user successfully registered, so login
             flask_login.login_user(user)


### PR DESCRIPTION
No longer causes internal server error when making a duplicate registration. See github issue #22  

Instead, it handles the IntegrityError exception by displaying a flash message and redirecting to the login page.